### PR TITLE
feat: :sparkles: add mobx store for documents

### DIFF
--- a/src/api/ApiDocumentController.ts
+++ b/src/api/ApiDocumentController.ts
@@ -3,20 +3,21 @@ import api from './index';
 import {
   ChangeDocument,
   CreateDocument,
+  CreateDocumentResponse,
   GetDocumentsResponse,
 } from 'src/types';
 
 class ApiDocumentController {
   public static async getDocumentById(
     id: number
-  ): Promise<AxiosResponse<ChangeDocument>> {
+  ): Promise<AxiosResponse<CreateDocumentResponse>> {
     return api.get(`/document/${id}`);
   }
 
   public static async updateDocumentById(
     id: number,
     data: ChangeDocument
-  ): Promise<AxiosResponse<ChangeDocument>> {
+  ): Promise<AxiosResponse<CreateDocumentResponse>> {
     return api.put(`/document/${id}`, data);
   }
 
@@ -45,7 +46,7 @@ class ApiDocumentController {
 
   public static async createDocument(
     data: CreateDocument
-  ): Promise<AxiosResponse<ChangeDocument>> {
+  ): Promise<AxiosResponse<CreateDocumentResponse>> {
     return api.post(`/document`, data);
   }
 

--- a/src/stores/Documents/documents.store.ts
+++ b/src/stores/Documents/documents.store.ts
@@ -1,0 +1,173 @@
+import { makeAutoObservable, runInAction } from 'mobx';
+import ApiDocumentController from '@api/ApiDocumentController';
+import {
+  CreateDocument,
+  ChangeDocument,
+  CreateDocumentResponse,
+} from 'src/types';
+
+class DocumentsStore {
+  private _document: CreateDocumentResponse | null = null;
+  private _documents: CreateDocumentResponse[] = [];
+  private _loading: boolean = false;
+  private _error: string | null = null;
+
+  constructor() {
+    makeAutoObservable(this, undefined, { autoBind: true });
+  }
+
+  get document() {
+    return this._document;
+  }
+
+  get documents() {
+    return this._documents;
+  }
+
+  get loading() {
+    return this._loading;
+  }
+
+  get error() {
+    return this._error;
+  }
+
+  async fetchDocumentById(id: number) {
+    this._loading = true;
+    try {
+      const response = await ApiDocumentController.getDocumentById(id);
+      runInAction(() => {
+        this._document = response.data;
+        this._error = null;
+      });
+    } catch (error) {
+      if (error instanceof Error) {
+        runInAction(() => {
+          this._error = error.message;
+        });
+      } else {
+        runInAction(() => {
+          this._error = 'An unknown error occurred';
+        });
+      }
+    } finally {
+      runInAction(() => {
+        this._loading = false;
+      });
+    }
+  }
+
+  async fetchDocuments(page?: number, size?: number) {
+    this._loading = true;
+    try {
+      const response = await ApiDocumentController.getDocuments(page, size);
+      runInAction(() => {
+        this._documents = response.data.content;
+        this._error = null;
+      });
+    } catch (error) {
+      if (error instanceof Error) {
+        runInAction(() => {
+          this._error = error.message;
+        });
+      } else {
+        runInAction(() => {
+          this._error = 'An unknown error occurred';
+        });
+      }
+    } finally {
+      runInAction(() => {
+        this._loading = false;
+      });
+    }
+  }
+
+  async createDocument(document: CreateDocument) {
+    this._loading = true;
+    try {
+      const response = await ApiDocumentController.createDocument(document);
+      runInAction(() => {
+        this._documents.push(response.data);
+        this._error = null;
+      });
+    } catch (error) {
+      if (error instanceof Error) {
+        runInAction(() => {
+          this._error = error.message;
+        });
+      } else {
+        runInAction(() => {
+          this._error = 'An unknown error occurred';
+        });
+      }
+    } finally {
+      runInAction(() => {
+        this._loading = false;
+      });
+    }
+  }
+
+  async updateDocument(id: number, document: ChangeDocument) {
+    this._loading = true;
+    try {
+      const response = await ApiDocumentController.updateDocumentById(
+        id,
+        document
+      );
+      runInAction(() => {
+        const index = this._documents.findIndex((doc) => doc.id === id);
+        if (index !== -1) {
+          this._documents[index] = {
+            ...this._documents[index],
+            ...response.data,
+          };
+        }
+        this._error = null;
+      });
+    } catch (error) {
+      if (error instanceof Error) {
+        runInAction(() => {
+          this._error = error.message;
+        });
+      } else {
+        runInAction(() => {
+          this._error = 'An unknown error occurred';
+        });
+      }
+    } finally {
+      runInAction(() => {
+        this._loading = false;
+      });
+    }
+  }
+
+  async deleteDocument(id: number) {
+    this._loading = true;
+    try {
+      await ApiDocumentController.deleteDocumentById(id);
+      runInAction(() => {
+        const index = this._documents.findIndex((doc) => doc.id === id);
+        if (index !== -1) {
+          this._documents.splice(index, 1);
+        }
+        this._error = null;
+      });
+    } catch (error) {
+      if (error instanceof Error) {
+        runInAction(() => {
+          this._error = error.message;
+        });
+      } else {
+        runInAction(() => {
+          this._error = 'An unknown error occurred';
+        });
+      }
+    } finally {
+      runInAction(() => {
+        this._loading = false;
+      });
+    }
+  }
+}
+
+export default new DocumentsStore();

--- a/src/stores/Documents/index.ts
+++ b/src/stores/Documents/index.ts
@@ -1,0 +1,2 @@
+import documentsStore from './documents.store';
+export { documentsStore };

--- a/src/stores/Documents/types.ts
+++ b/src/stores/Documents/types.ts
@@ -1,0 +1,13 @@
+import { ChangeDocument, CreateDocumentResponse } from 'src/types';
+
+export interface DocumentsStoreProps {
+  document: CreateDocumentResponse | null;
+  documents: CreateDocumentResponse[];
+  loading: boolean;
+  error: string | null;
+  getDocument: (id: number) => Promise<void>;
+  getDocuments: () => Promise<void>;
+  createDocument: (document: ChangeDocument) => Promise<void>;
+  updateDocument: (id: number, document: ChangeDocument) => Promise<void>;
+  deleteDocument: (id: number) => Promise<void>;
+}

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -1,1 +1,2 @@
 export * from './Auth';
+export * from './Documents';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -127,6 +127,15 @@ export type ChangeDocument = {
   data?: string;
 };
 
+export type CreateDocumentResponse = {
+  id: number;
+  documentName: string;
+  createdAt: string;
+  updatedAt: string;
+  contentUrl: string;
+  documentId: number;
+};
+
 export type GetDocumentsResponse = Pagination & {
-  content: ChangeDocument[];
+  content: CreateDocumentResponse[];
 };


### PR DESCRIPTION
Дополнительно создал тип CreateDocumentResponse (он требуется для типизации ответа сервера get/document, get/document/{id}, put/document/{id}). Заменил в ApiDocumentController типы для этих ответов сервера.

Переименовал файл "ApiDocumentContoller.ts" на "ApiDocumentCont**r**oller.ts".

Добавил store для документов.