### PR TITLE
feat: :sparkles: added user pages structure

### DIFF
--- a/src/components/App/providers/router/AppRouter.tsx
+++ b/src/components/App/providers/router/AppRouter.tsx
@@ -1,6 +1,10 @@
 import { DocAttributesAdminPage } from '@pages/DocAttributesAdminPage';
 import { DocTypesAdminPage } from '@pages/DocTypesAdminPage';
+import { UserAwaitingSignPage } from '@pages/UserAwaitingSignPage';
+import { UserDashboardIndexPage } from '@pages/UserDashboardIndexPage';
+import UserDocumentsPage from '@pages/UserDocumentsPage/UserDocumentsPage';
 import { UsersAdminPage } from '@pages/UsersAdminPage';
+import { UserSentForSignPage } from '@pages/UserSentForSignPage';
 import { Suspense } from 'react';
 import { Navigate, Route, Routes } from 'react-router-dom';
 import Layout from 'src/components/Layout/Layout';
@@ -31,8 +35,22 @@ const AppRouter = () => {
           <Route element={<ProtectedRoute role="USER" />}>
             <Route index element={<Navigate replace to="app" />} />
             <Route path={ROUTE_CONSTANTS.APP} element={<UserDashboardPage />}>
-              <Route path="documents" element={<DocumentsPage />} />
-              <Route path="users" element={<UsersPage />} />
+              <Route
+                path={ROUTE_CONSTANTS.USER_DASHBOARD_INDEX}
+                element={<UserDashboardIndexPage />}
+              />
+              <Route
+                path={ROUTE_CONSTANTS.USER_DOCUMENTS}
+                element={<UserDocumentsPage />}
+              />
+              <Route
+                path={ROUTE_CONSTANTS.USER_SENT_FOR_SIGN}
+                element={<UserSentForSignPage />}
+              />
+              <Route
+                path={ROUTE_CONSTANTS.USER_AWAITING_SIGN}
+                element={<UserAwaitingSignPage />}
+              />
             </Route>
           </Route>
           <Route element={<ProtectedRoute role="ADMIN" />}>

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -1,10 +1,17 @@
 export const ROUTE_CONSTANTS = {
   SIGN_IN: '/sign-in',
   SIGN_UP: '/sign-up',
+
   APP: 'app',
+  USER_DASHBOARD_INDEX: '',
+  USER_DOCUMENTS: 'documents',
+  USER_SENT_FOR_SIGN: 'sent-for-sign',
+  USER_AWAITING_SIGN: 'awaiting-sign',
+
   ADMIN: 'admin',
   USERS: 'users-admin',
   DOC_TYPES_ADMIN: 'document-types-admin',
   DOC_ATTRIBUTES_ADMIN: 'document-attributes-admin',
+
   NOT_FOUND: '*',
 };

--- a/src/constants/sideBar.ts
+++ b/src/constants/sideBar.ts
@@ -1,5 +1,11 @@
 import { ROUTE_CONSTANTS } from '@constants/routes';
-import { Users, FileStack, Calendar } from 'lucide-react';
+import {
+  Users,
+  FileStack,
+  Calendar,
+  FileInput,
+  FileOutput,
+} from 'lucide-react';
 
 export const adminMenuItems = [
   {
@@ -16,5 +22,23 @@ export const adminMenuItems = [
     title: 'Атрибуты документов',
     url: ROUTE_CONSTANTS.DOC_ATTRIBUTES_ADMIN,
     icon: Calendar,
+  },
+];
+
+export const userMenuItems = [
+  {
+    title: 'Мои документы',
+    url: ROUTE_CONSTANTS.USER_DOCUMENTS,
+    icon: FileStack,
+  },
+  {
+    title: 'Отправленные на подпись',
+    url: ROUTE_CONSTANTS.USER_SENT_FOR_SIGN,
+    icon: FileOutput,
+  },
+  {
+    title: 'Ожидают подписания',
+    url: ROUTE_CONSTANTS.USER_AWAITING_SIGN,
+    icon: FileInput,
   },
 ];

--- a/src/pages/UserAwaitingSignPage/UserAwaitingSignPage.async.tsx
+++ b/src/pages/UserAwaitingSignPage/UserAwaitingSignPage.async.tsx
@@ -1,0 +1,3 @@
+import { lazy } from 'react';
+
+export const UserAwaitingSignPageAsync = lazy(() => import('./UserAwaitingSignPage'));

--- a/src/pages/UserAwaitingSignPage/UserAwaitingSignPage.tsx
+++ b/src/pages/UserAwaitingSignPage/UserAwaitingSignPage.tsx
@@ -1,0 +1,5 @@
+const UserAwaitingSignPage = () => {
+  return <section>AwaitingSignPage</section>;
+};
+
+export default UserAwaitingSignPage;

--- a/src/pages/UserAwaitingSignPage/index.tsx
+++ b/src/pages/UserAwaitingSignPage/index.tsx
@@ -1,0 +1,1 @@
+export { UserAwaitingSignPageAsync as UserAwaitingSignPage } from './UserAwaitingSignPage.async';

--- a/src/pages/UserDashboardIndexPage/UserDashboardIndexPage.async.tsx
+++ b/src/pages/UserDashboardIndexPage/UserDashboardIndexPage.async.tsx
@@ -1,0 +1,3 @@
+import { lazy } from 'react';
+
+export const UserDashboardIndexPageAsync = lazy(() => import('./UserDashboardIndexPage'));

--- a/src/pages/UserDashboardIndexPage/UserDashboardIndexPage.tsx
+++ b/src/pages/UserDashboardIndexPage/UserDashboardIndexPage.tsx
@@ -1,0 +1,5 @@
+const UserDashboardIndexPage = () => {
+  return <section>DashboardIndexPage</section>;
+};
+
+export default UserDashboardIndexPage;

--- a/src/pages/UserDashboardIndexPage/index.ts
+++ b/src/pages/UserDashboardIndexPage/index.ts
@@ -1,0 +1,1 @@
+export { UserDashboardIndexPageAsync as UserDashboardIndexPage } from './UserDashboardIndexPage.async';

--- a/src/pages/UserDashboardPage/UserDashboardPage.tsx
+++ b/src/pages/UserDashboardPage/UserDashboardPage.tsx
@@ -1,14 +1,35 @@
 import { Outlet } from 'react-router-dom';
 import HeaderDashboard from '@components/HeaderDashboard/HeaderDashboard';
+import { Suspense, useState } from 'react';
+import {
+  SidebarProvider,
+  SidebarTrigger,
+} from '@components/UI/Sidebar/Sidebar';
+import { AppSidebar } from '@components/AppSidebar/AppSidebar';
+import { userMenuItems } from '@constants/sideBar';
+import { Spinner } from '@components/UI';
 
 const UserDashboardPage = () => {
+  const [isSidebarOpen, setIsSidebarOpen] = useState(true);
+
   return (
-    <section className="h-[calc(100vh-140px)]">
-      <HeaderDashboard />
-      <div className="px-4 md:px-8 lg:px-40">
-        UserDashboardPage
-      </div>
-      <Outlet />
+    <section className="h-[calc(100vh-130px)]  flex relative px-4 md:px-8 lg:px-40">
+      <SidebarProvider open={isSidebarOpen} onOpenChange={setIsSidebarOpen}>
+        <AppSidebar
+          sidebarName="Панель пользователя"
+          menuItems={userMenuItems}
+        />
+        <Suspense
+          fallback={
+            <div className="flex justify-center items-center flex-grow h-full">
+              <Spinner />
+            </div>
+          }
+        >
+          <SidebarTrigger />
+          <Outlet />
+        </Suspense>
+      </SidebarProvider>
     </section>
   );
 };

--- a/src/pages/UserDocumentsPage/UserDocumentsPage.async.tsx
+++ b/src/pages/UserDocumentsPage/UserDocumentsPage.async.tsx
@@ -1,0 +1,3 @@
+import { lazy } from 'react';
+
+export const UserDocumentsPageAsync = lazy(() => import('./UserDocumentsPage'));

--- a/src/pages/UserDocumentsPage/UserDocumentsPage.tsx
+++ b/src/pages/UserDocumentsPage/UserDocumentsPage.tsx
@@ -1,0 +1,5 @@
+const UserDocumentsPage = () => {
+  return <section>DocumentsPage</section>;
+};
+
+export default UserDocumentsPage;

--- a/src/pages/UserDocumentsPage/index.ts
+++ b/src/pages/UserDocumentsPage/index.ts
@@ -1,0 +1,1 @@
+export { UserDocumentsPageAsync as UserDocumentsPage } from './UserDocumentsPage.async';

--- a/src/pages/UserSentForSignPage/UserSentForSignPage.async.tsx
+++ b/src/pages/UserSentForSignPage/UserSentForSignPage.async.tsx
@@ -1,0 +1,3 @@
+import { lazy } from 'react';
+
+export const UserSentForSignPageAsync = lazy(() => import('./UserSentForSignPage'));

--- a/src/pages/UserSentForSignPage/UserSentForSignPage.tsx
+++ b/src/pages/UserSentForSignPage/UserSentForSignPage.tsx
@@ -1,0 +1,5 @@
+const UserSentForSignPage = () => {
+  return <section>SentForSignPage</section>;
+};
+
+export default UserSentForSignPage;

--- a/src/pages/UserSentForSignPage/index.ts
+++ b/src/pages/UserSentForSignPage/index.ts
@@ -1,0 +1,1 @@
+export { UserSentForSignPageAsync as UserSentForSignPage } from './UserSentForSignPage.async';


### PR DESCRIPTION
Добавил на странице пользователя sidebar, аналогично админке.

Добавил 4 страницы-заглушки:
1. Основная страница dashboard, где можно добавить общую информацию о документах пользователя; (/app)
2. Страница с документами пользователя; (/app/documents)
3. Страница с документами отправленными на подписание; (/app/sent-for-sign)
4. Страница с документами ожидающих подписание. (/app/awaiting-sign)