### PR TITLE
fix: :bug: Fix user redirect to /* after sign in

### DIFF
--- a/src/pages/SignInPage/SignInPage.tsx
+++ b/src/pages/SignInPage/SignInPage.tsx
@@ -35,12 +35,17 @@ const SignInPage: FC<SignInPageProps> = observer(() => {
   const form = useForm<UserLogin>();
 
   useEffect(() => {
-    if (authStore.isAuth && authStore.status === STATUS.SUCCESS) {
-      const userRoles = usersStore.user?.roles || [];
-      const isAdmin = userRoles.some((role) => role.name === 'ADMIN');
-
-      navigate(isAdmin ? '/admin' : '/app', { replace: true });
+    const navigateToApp = async () => {
+      if (authStore.isAuth && authStore.status === STATUS.SUCCESS) {
+        await usersStore.fetchUserData();
+        const userRoles = usersStore.user?.roles || [];
+        const isAdmin = userRoles.some((role) => role.name === 'ADMIN');
+  
+        navigate(isAdmin ? '/admin' : '/app', { replace: true });
+      }
     }
+    
+    navigateToApp();
   }, [authStore.status, authStore.isAuth]);
 
   const onSubmit = async (payload: UserLogin) => {


### PR DESCRIPTION
Исправил перенаправление на страницу /*

ошибка заключилась в том, что userStore хранил в себе прошлого пользователя, и если мы вышли с пользователя с ролями ADMIN, USER и пытаемся зайти на пользователя с только USER ролью, то ProtectedRouteSuccess перенаправлял на NotFound из-за того, что там он проверяет есть ли у пользователя роль ADMIN, а должна проверять есть ли роль USER