### PR TITLE
fix: :bug: Поправляет двойной рендер таблиц

### DIFF
--- a/src/components/CreateUser/CreateUserForm.tsx
+++ b/src/components/CreateUser/CreateUserForm.tsx
@@ -131,6 +131,13 @@ export const CreateUserForm = ({
             className="block hover:opacity-75 mb-3 bg-bg-header hover:bg-bg-header"
             type="submit"
             onClick={handleOnSave}
+            disabled={
+              !inputs.firstName ||
+              !inputs.lastName ||
+              !inputs.email ||
+              !inputs.password ||
+              !inputs.login
+            }
           >
             Сохранить
           </Button>

--- a/src/pages/AttributesPage/AttributesPage.tsx
+++ b/src/pages/AttributesPage/AttributesPage.tsx
@@ -40,7 +40,15 @@ const AttributesPage: FC<AttributesPageProps> = observer(() => {
   } = attributesStore;
 
   useEffect(() => {
-    void fetchDocTypesAndAttributes(page ?? 0, limit ?? 20);
+    // Если query.page и query.limit не определены, устанавливаем дефолтные значения
+    if (page === undefined || limit === undefined) {
+      setQuery({
+        page: 0,
+        limit: 20,
+      });
+    } else {
+      void fetchDocTypesAndAttributes(page ?? 0, limit ?? 20);
+    }
   }, [fetchDocTypesAndAttributes, page, limit]);
 
   if (loading) {

--- a/src/pages/DocumentsTypePage/DocumentsTypePage.tsx
+++ b/src/pages/DocumentsTypePage/DocumentsTypePage.tsx
@@ -41,7 +41,15 @@ const DocumentsTypePage: FC<DocumentsTypePageProps> = observer(() => {
   } = documentTypesStore;
 
   useEffect(() => {
-    void fetchDocTypesAndAttributes(page ?? 0, limit ?? 20);
+    // Если query.page и query.limit не определены, устанавливаем дефолтные значения
+    if (page === undefined || limit === undefined) {
+      setQuery({
+        page: 0,
+        limit: 20,
+      });
+    } else {
+      void fetchDocTypesAndAttributes(page ?? 0, limit ?? 20);
+    }
   }, [fetchDocTypesAndAttributes, page, limit]);
 
   if (isLoading) {

--- a/src/pages/UserAwaitingSignPage/UserAwaitingSignPage.tsx
+++ b/src/pages/UserAwaitingSignPage/UserAwaitingSignPage.tsx
@@ -29,10 +29,18 @@ const UserAwaitingSignPage = observer(() => {
   } = documentsStore;
 
   useEffect(() => {
-    void documentsStore.fetchDocumentsForSign(
-      query.page ?? 0,
-      query.limit ?? 20
-    );
+    // Если query.page и query.limit не определены, устанавливаем дефолтные значения
+    if (query.page === undefined || query.limit === undefined) {
+      setQuery({
+        page: 0,
+        limit: 20,
+      });
+    } else {
+      void documentsStore.fetchDocumentsForSign(
+        query.page ?? 0,
+        query.limit ?? 20
+      );
+    }
   }, [query.limit, query.page]);
 
   if (loading) {

--- a/src/pages/UserDocumentsPage/UserDocumentsPage.tsx
+++ b/src/pages/UserDocumentsPage/UserDocumentsPage.tsx
@@ -38,7 +38,15 @@ const UserDocumentsPage = observer(() => {
   } = documentsStore;
 
   useEffect(() => {
-    void documentsStore.fetchDocuments(query.page ?? 0, query.limit ?? 20);
+    // Если query.page и query.limit не определены, устанавливаем дефолтные значения
+    if (query.page === undefined || query.limit === undefined) {
+      setQuery({
+        page: 0,
+        limit: 20,
+      });
+    } else {
+      void documentsStore.fetchDocuments(query.page ?? 0, query.limit ?? 20);
+    }
   }, [query.limit, query.page]);
 
   const {

--- a/src/pages/UserSentForSignPage/UserSentForSignPage.tsx
+++ b/src/pages/UserSentForSignPage/UserSentForSignPage.tsx
@@ -22,20 +22,25 @@ const UserSentForSignPage = observer(() => {
     documentsStore;
 
   useEffect(() => {
-    void documentsStore.fetchDocuments(
-      query.page ?? 0, //+ 1
-      query.limit ?? 20
-    );
+    // Если query.page и query.limit не определены, устанавливаем дефолтные значения
+    if (query.page === undefined || query.limit === undefined) {
+      setQuery({
+        page: 0,
+        limit: 20,
+      });
+    } else {
+      void documentsStore.fetchDocuments(
+        query.page ?? 0, //+ 1
+        query.limit ?? 20
+      );
+    }
   }, [query.limit, query.page]);
 
   const { fetchDocTypesAndAttributes, isLoading } = documentTypesStore;
 
   useEffect(() => {
     fetchDocTypesAndAttributes(0, 100);
-    fetchDocuments(
-      query.page ?? 0, //+ 1
-      query.limit ?? 20
-    );
+    fetchDocuments(0, 20);
   }, []);
 
   if (loading || isLoading) {

--- a/src/pages/UserSignedDocuments/UserSignedDocuments.tsx
+++ b/src/pages/UserSignedDocuments/UserSignedDocuments.tsx
@@ -24,15 +24,23 @@ const UserSignedDocuments = observer(() => {
   } = documentsStore;
 
   useEffect(() => {
-    void fetchDocumentsForSign(
-      query.page ?? 0,
-      query.limit ?? 20,
-      'after_signer'
-    );
+    // Если query.page и query.limit не определены, устанавливаем дефолтные значения
+    if (query.page === undefined || query.limit === undefined) {
+      setQuery({
+        page: 0,
+        limit: 20,
+      });
+    } else {
+      void fetchDocumentsForSign(
+        query.page ?? 0,
+        query.limit ?? 20,
+        'after_signer'
+      );
+    }
   }, [query.limit, query.page]);
 
   useEffect(() => {
-    fetchDocumentsForSign(0, 100, 'after_signer');
+    fetchDocumentsForSign(0, 20, 'after_signer');
   }, []);
 
   if (loading) {

--- a/src/pages/UsersAdminPage/UsersAdminPage.tsx
+++ b/src/pages/UsersAdminPage/UsersAdminPage.tsx
@@ -32,9 +32,18 @@ const UsersAdminPage = observer(() => {
     pagination,
     createUser,
   } = usersStore;
+
   useEffect(() => {
-    void fetchUsers(query.page ?? 0, query.limit ?? 20);
-  }, [query.limit, query.page, fetchUsers]);
+    // Если query.page и query.limit не определены, устанавливаем дефолтные значения
+    if (query.page === undefined || query.limit === undefined) {
+      setQuery({
+        page: 0,
+        limit: 20,
+      });
+    } else {
+      void fetchUsers(query.page ?? 0, query.limit ?? 20);
+    }
+  }, [query.page, query.limit, fetchUsers]);
 
   if (isLoading) {
     return (


### PR DESCRIPTION
Проблема была в том,что таблицы несколько раз пытались получить данные страницы и лимита,так как долго устанавливается дефолтное значение,у нас происходил двойной рендер.
1 раз значения undefind
2 раз с дефолтными значениями
Сейчас перед отрисовкой мы проверяем,что дефолтные значения или значения параметров мы получили