### PR TITLE
fix: :bug: fix action delete | adjust pagination

### DIFF
--- a/src/components/Action/ActionDelete.tsx
+++ b/src/components/Action/ActionDelete.tsx
@@ -14,6 +14,8 @@ import {
 import { Trash } from 'lucide-react';
 import { ActionDefaultData } from './types';
 import { useLocation, useNavigate } from 'react-router-dom';
+import { deleteValidStates } from '@constants/userDocument';
+import { DocumentState } from '@/types/state';
 
 interface ActionDeleteProps<TData>
   extends ActionDefaultData<TData>,
@@ -22,7 +24,9 @@ interface ActionDeleteProps<TData>
   onDeleteWithNumberId?: (id: number) => Promise<void>;
 }
 
-export const ActionDelete = <TData,>({
+export const ActionDelete = <
+  TData extends { id: number; state: DocumentState },
+>({
   onDeleteWithNumberId,
   onDeleteWithStringId,
   data,
@@ -35,7 +39,7 @@ export const ActionDelete = <TData,>({
     const id = typeof data === 'object' && data && 'id' in data && data?.id;
 
     const handleNavigation = () => {
-      if (location.pathname !== '/app/documents') {
+      if (location.pathname.startsWith(`/app/${id as number}`)) {
         navigate('../documents');
       }
     };
@@ -51,34 +55,36 @@ export const ActionDelete = <TData,>({
     }
   };
 
-  return (
-    <AlertDialog>
-      <AlertDialogTrigger asChild>
-        <Button variant="ghost" {...props}>
-          <Trash />
-          Удалить
-        </Button>
-      </AlertDialogTrigger>
-      <AlertDialogContent>
-        <AlertDialogHeader>
-          <AlertDialogTitle>Вы точно уверены?</AlertDialogTitle>
-          <AlertDialogDescription>
-            Это действие не может быть отменено. Эта операция удалит данные с
-            сервера.
-          </AlertDialogDescription>
-        </AlertDialogHeader>
-        <AlertDialogFooter>
-          <AlertDialogCancel className="mb-3 hover:bg-bg-header">
-            Отменить
-          </AlertDialogCancel>
-          <AlertDialogAction
-            className="hover:opacity-75 mb-3 bg-bg-header hover:bg-bg-header"
-            onClick={handleClick}
-          >
-            Продолжить
-          </AlertDialogAction>
-        </AlertDialogFooter>
-      </AlertDialogContent>
-    </AlertDialog>
-  );
+  if (data && deleteValidStates.includes(data?.state)) {
+    return (
+      <AlertDialog>
+        <AlertDialogTrigger asChild>
+          <Button variant="ghost" {...props}>
+            <Trash />
+            Удалить
+          </Button>
+        </AlertDialogTrigger>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Вы точно уверены?</AlertDialogTitle>
+            <AlertDialogDescription>
+              Это действие не может быть отменено. Эта операция удалит данные с
+              сервера.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel className="mb-3 hover:bg-bg-header">
+              Отменить
+            </AlertDialogCancel>
+            <AlertDialogAction
+              className="hover:opacity-75 mb-3 bg-bg-header hover:bg-bg-header"
+              onClick={handleClick}
+            >
+              Продолжить
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    );
+  }
 };

--- a/src/components/DataTable2/ui/TableSelectCountRow.tsx
+++ b/src/components/DataTable2/ui/TableSelectCountRow.tsx
@@ -17,7 +17,7 @@ export const TableSelectCountRow = <TData,>({
           table.setPageSize(Number(e.target.value));
         }}
       >
-        {[20, 50, 100, 500].map((pageSize) => (
+        {[20, 50, 100].map((pageSize) => (
           <option key={pageSize} value={pageSize}>
             {pageSize}
           </option>

--- a/src/constants/userDocument.ts
+++ b/src/constants/userDocument.ts
@@ -95,3 +95,11 @@ export const DIALOGS_USER: Record<string, DialogTexts> = {
     btnTriggerText: BUTTONS_NAMES.edit,
   },
 };
+
+// статусы для документов, которые можно удалять
+export const deleteValidStates = [
+  'DRAFT',
+  'APPROVED',
+  'REJECTED',
+  'REWORK_REQUIRED',
+];

--- a/src/pages/DocumentPage/DocumentPage.tsx
+++ b/src/pages/DocumentPage/DocumentPage.tsx
@@ -16,12 +16,11 @@ import { DocumentState } from '@/types/state';
 import { UserSelectDialog } from '@components/UserSelectDialog/UserSelectDialog';
 import { Voting } from 'src/types';
 import { ActionDelete } from '@components/Action';
+import { deleteValidStates } from '@constants/userDocument';
 
 interface DocumentPageProps {
   type: string;
 }
-
-const deleteValidStates = ['DRAFT', 'APPROVED', 'REJECTED', 'REWORK_REQUIRED'];
 
 const DocumentPage: FC<DocumentPageProps> = observer(({ type }) => {
   const navigate = useNavigate();


### PR DESCRIPTION
1. Убрал функцию удаления для документов, которые не получился удалить с бэкэнда.
#74 
2. При удалении будет перекидывать на app/documents/ только со страницы документа.
3. Убрал возможность выбрать вывод 500 элементов в таблице, т.к. бэк возвращает ошибку.